### PR TITLE
Compute stats on full (unpaginated) queryset

### DIFF
--- a/admin_totals/admin.py
+++ b/admin_totals/admin.py
@@ -14,7 +14,7 @@ class ChangeListTotals(ChangeList):
             for field in self.list_display:
                 if field in list_totals:
                     self.aggregations.append(
-                        self.result_list.aggregate(agg=list_totals[field](field))['agg'])
+                        self.queryset.aggregate(agg=list_totals[field](field))['agg'])
                 else:
                     self.aggregations.append('')
 


### PR DESCRIPTION
Hey !

Had the same needs than #7, so here's a PR. It displays the total of the whole dataset, taking filters into account.

@douwevandermeij In #7 you mention some unexpected results in some case with this approach, can you elaborate ?  I did not test much yet, but initially it seems to work fine.

Is there a valid use case for paginated results (current behaviour) ? If yes, we would need to add a way to define whether totals must be per page or global (either adding a third parameter to list_total's tuples, or a setting).

Thanks for the package !